### PR TITLE
feature(commit-types): add release as new type

### DIFF
--- a/packages/commit-types-peakfijn/index.json
+++ b/packages/commit-types-peakfijn/index.json
@@ -47,6 +47,12 @@
 		"summary": "Updating code and changing the meaning of it",
 		"description": "TODO: refactor description"
 	},
+	"release": {
+		"release": null,
+		"name": "Releases",
+		"summary": "Modifying all files required to define a new release version",
+		"description": "TODO: release description"
+	},
 	"chore": {
 		"release": "patch",
 		"name": "Other chores",


### PR DESCRIPTION
When you create a new release with semantic releases it creates a `chore` type commit. This commit includes all changes required for pushing a new version. But because `chore` also triggers a new patch version, this can be "looped". When someone creates a new release, and accidentally reruns the script, it will create yet another release.