### PR TITLE
Use proper homepage url

### DIFF
--- a/packages/commit-types-peakfijn/package.json
+++ b/packages/commit-types-peakfijn/package.json
@@ -10,7 +10,7 @@
 	"author": "Cedric van Putten <cedric@peakfijn.nl>",
 	"license": "MIT",
 	"main": "index.json",
-	"homepage": "https://github.com/peakfijn/conventions#readme",
+	"homepage": "https://github.com/peakfijn/conventions/tree/develop/packages/commit-types-peakfijn#readme",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/peakfijn/conventions.git"

--- a/packages/commitlint-config-peakfijn/package.json
+++ b/packages/commitlint-config-peakfijn/package.json
@@ -9,7 +9,7 @@
 	"author": "Cedric van Putten <cedric@peakfijn.nl>",
 	"license": "MIT",
 	"main": "index.js",
-	"homepage": "https://github.com/peakfijn/peakfijn-conventions#readme",
+	"homepage": "https://github.com/peakfijn/peakfijn-conventions/tree/develop/packages/commitlint-config-peakfijn#readme",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/peakfijn/peakfijn-conventions.git"

--- a/packages/conventional-changelog-peakfijn/package.json
+++ b/packages/conventional-changelog-peakfijn/package.json
@@ -10,7 +10,7 @@
 	"author": "Cedric van Putten <cedric@peakfijn.nl>",
 	"license": "MIT",
 	"main": "index.js",
-	"homepage": "https://github.com/peakfijn/conventions#readme",
+	"homepage": "https://github.com/peakfijn/conventions/tree/develop/packages/conventional-changelog-peakfijn#readme",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/peakfijn/conventions.git"

--- a/packages/cz-changelog-peakfijn/package.json
+++ b/packages/cz-changelog-peakfijn/package.json
@@ -10,7 +10,7 @@
 	"author": "Cedric van Putten <cedric@peakfijn.nl>",
 	"license": "MIT",
 	"main": "index.js",
-	"homepage": "https://github.com/peakfijn/conventions#readme",
+	"homepage": "https://github.com/peakfijn/conventions/tree/develop/packages/cz-changelog-peakfijn#readme",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/peakfijn/conventions.git"

--- a/packages/release-rules-peakfijn/package.json
+++ b/packages/release-rules-peakfijn/package.json
@@ -11,7 +11,7 @@
 	"author": "Cedric van Putten <cedric@peakfijn.nl>",
 	"license": "MIT",
 	"main": "index.js",
-	"homepage": "https://github.com/peakfijn/conventions#readme",
+	"homepage": "https://github.com/peakfijn/conventions/tree/develop/packages/release-rules-peakfijn#readme",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/peakfijn/conventions.git"


### PR DESCRIPTION
When opening the repository or homepage URL from NPM, all packages are linking to the root. This feels a bit weird because you selected a specific version. Instead, the package should link to its dedicated readme page.