### PR TITLE
Shareable Semantic Release Expo configuration

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -11,4 +11,5 @@ rules:
       - commit-types
       - commitizen
       - commitlint
+      - config-release-expo
       - release-rules

--- a/@peakfijn/config-release-expo/index.js
+++ b/@peakfijn/config-release-expo/index.js
@@ -1,0 +1,53 @@
+module.exports = {
+	branch: 'develop',
+	tagFormat: '${version}',
+	analyzeCommits: {
+		path: '@semantic-release/commit-analyzer',
+		preset: 'peakfijn',
+		releaseRules: 'release-rules-peakfijn',
+	},
+	generateNotes: [
+		{
+			path: '@semantic-release/release-notes-generator',
+			preset: 'peakfijn',
+		},
+	],
+	verifyConditions: [
+		'@semantic-release/changelog',
+		'@semantic-release/npm',
+		'semantic-release-expo',
+		'semantic-release-git-branches',
+	],
+	prepare: [
+		'@semantic-release/changelog',
+		{
+			path: '@semantic-release/npm',
+			npmPublish: false,
+		},
+		{
+			path: 'semantic-release-expo',
+			manifests: [
+				'app.test.json',
+				'app.staging.json',
+				'app.production.json',
+			],
+		},
+		{
+			path: 'semantic-release-git-branches',
+			branchPush: true,
+			branchMerges: ['develop', 'master'],
+			message: 'release: create new version ${nextRelease.version}\n\n${nextRelease.notes}',
+			assets: [
+				'CHANGELOG.md',
+				'app.test.json',
+				'app.staging.json',
+				'app.production.json',
+				'package.json',
+				'package-lock.json',
+			],
+		},
+	],
+	publish: false,
+	success: false,
+	fail: false,
+};

--- a/@peakfijn/config-release-expo/package.json
+++ b/@peakfijn/config-release-expo/package.json
@@ -1,0 +1,37 @@
+{
+	"name": "@peakfijn/config-release-expo",
+	"version": "0.0.0",
+	"description": "Sharable configuration for Semantic Releases with Expo",
+	"keywords": [
+		"semantic",
+		"release",
+		"config",
+		"expo",
+		"peakfijn"
+	],
+	"author": "Cedric van Putten <cedric@peakfijn.nl>",
+	"license": "MIT",
+	"main": "index.js",
+	"homepage": "https://github.com/peakfijn/conventions/tree/develop/@peakfijn/config-release-expo#readme",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/peakfijn/conventions.git"
+	},
+	"bugs": {
+		"url": "https://github.com/peakfijn/conventions/issues"
+	},
+	"scripts": {
+		"test": "node -c index.js"
+	},
+	"dependencies": {
+		"@semantic-release/changelog": "^3.0.0",
+		"@semantic-release/commit-analyzer": "^6.0.0",
+		"@semantic-release/npm": "^5.0.1",
+		"@semantic-release/release-notes-generator": "^7.0.0",
+		"conventional-changelog-peakfijn": "^0.5.0",
+		"release-rules-peakfijn": "^0.5.0",
+		"semantic-release": "^15.9.5",
+		"semantic-release-expo": "^1.2.1",
+		"semantic-release-git-branches": "^1.2.1"
+	}
+}

--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -2,6 +2,7 @@
 	"groups": {
 		"default": {
 			"packages": [
+				"@peakfijn/config-release-expo/package.json",
 				"package.json",
 				"packages/commit-types-peakfijn/package.json",
 				"packages/commitlint-config-peakfijn/package.json",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,7 @@
 {
 	"lerna": "3.0.0-beta.21",
 	"packages": [
+		"@peakfijn/*",
 		"packages/*"
 	],
 	"version": "0.5.0",


### PR DESCRIPTION
This introduces the first draft of the Semantic Release configuration for Expo releases. It assumes you have manifests for `test`, `staging` and `production`. Other than that, it's pretty straightforward. It also groups a couple of packages so we won't have to litter the project dependency list.