### PR TITLE
Use new release commit type

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -9,7 +9,7 @@
 			"allowBranch": "master",
 			"exact": true,
 			"force-publish": "*",
-			"message": "chore: publish new release %s"
+			"message": "release: create new version %s"
 		}
 	}
 }


### PR DESCRIPTION
This changes the message Lerna adds to new releases. It's nothing significant but merely a bit more semantic change.