### PR TITLE
fix(release-rules): include default breaking and revert rules

### DIFF
--- a/packages/release-rules-peakfijn/index.js
+++ b/packages/release-rules-peakfijn/index.js
@@ -1,7 +1,13 @@
 'use strict';
 
 const commitTypes = require('commit-types-peakfijn');
+const defaultRules = [
+	{ breaking: true, release: 'major' },
+	{ revert: true, release: 'patch' },
+];
 
-module.exports = Object.keys(commitTypes)
-	.map(type => ({ type, release: commitTypes[type].release }))
-	.filter(rule => !!rule.release);
+module.exports = defaultRules.concat(
+	Object.keys(commitTypes)
+		.map(type => ({ type, release: commitTypes[type].release }))
+		.filter(rule => !!rule.release)
+);


### PR DESCRIPTION
Without this breaking changes are not handled as breaking changes. This makes sure both breaking and revert commits are handled properly.