### PR TITLE
feature(config-commitizen): add first draft of commitizen config

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -11,6 +11,7 @@ rules:
       - commit-types
       - commitizen
       - commitlint
+      - config-commitizen
       - config-release-expo
       - config-release-laravel
       - release-rules

--- a/@peakfijn/config-commitizen/README.md
+++ b/@peakfijn/config-commitizen/README.md
@@ -1,0 +1,33 @@
+# Commitizen - Peakfijn
+
+A sharable [Commitizen](https://github.com/commitizen/cz-cli) configuration with Peakfijn conventions.
+
+## Installation
+
+Install the dependency with npm.
+
+```bash
+$ npm install --save-dev @peakfijn/config-commitizen
+```
+
+## Configuration
+
+Update the `package.json` to include a [commitizen config](https://github.com/commitizen/cz-cli#making-your-repo-commitizen-friendly) property.
+
+```json
+{
+	"config": {
+		"commitizen": {
+			"path": "@peakfijn/config-commitizen"
+		}
+	}
+}
+```
+
+## Usage
+
+After installing and configuring the package, you can use it by running this command.
+
+```bash
+$ npx git-cz
+```

--- a/@peakfijn/config-commitizen/index.js
+++ b/@peakfijn/config-commitizen/index.js
@@ -1,0 +1,3 @@
+const config = require('cz-changelog-peakfijn');
+
+module.exports = config;

--- a/@peakfijn/config-commitizen/package.json
+++ b/@peakfijn/config-commitizen/package.json
@@ -1,0 +1,28 @@
+{
+	"name": "@peakfijn/config-commitizen",
+	"version": "0.6.1",
+	"description": "Sharable configuration for Commitizen with Peakfijn conventions",
+	"keywords": [
+		"commitizen",
+		"config",
+		"peakfijn"
+	],
+	"author": "Cedric van Putten <cedric@peakfijn.nl>",
+	"license": "MIT",
+	"main": "index.js",
+	"homepage": "https://github.com/peakfijn/conventions/tree/develop/@peakfijn/config-commitizen#readme",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/peakfijn/conventions.git"
+	},
+	"bugs": {
+		"url": "https://github.com/peakfijn/conventions/issues"
+	},
+	"scripts": {
+		"test": "node -c index.js"
+	},
+	"dependencies": {
+		"commitizen": "^2.10.1",
+		"cz-changelog-peakfijn": "0.6.1"
+	}
+}

--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -2,6 +2,7 @@
 	"groups": {
 		"default": {
 			"packages": [
+				"@peakfijn/config-commitizen/package.json",
 				"@peakfijn/config-release-expo/package.json",
 				"@peakfijn/config-release-laravel/package.json",
 				"package.json",


### PR DESCRIPTION
This allows us to "implement" commitizen using only `npm install --save-dev @peakfijn/commitizen` and the `package.json` configuration.