### PR TITLE
feature(config-commitlint): add first draft of commitlint config

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -11,6 +11,7 @@ rules:
       - commit-types
       - commitizen
       - commitlint
+      - config-commitlint
       - config-release-expo
       - config-release-laravel
       - release-rules

--- a/@peakfijn/config-commitlint/README.md
+++ b/@peakfijn/config-commitlint/README.md
@@ -1,0 +1,33 @@
+# Commitlint - Peakfijn
+
+A sharable [Commitlint](https://github.com/marionebl/commitlint) configuration with Peakfijn conventions.
+
+## Installation
+
+Install the dependency with npm.
+
+```bash
+$ npm install --save-dev @peakfijn/config-commitlint
+```
+
+## Configuration
+
+Update the `package.json` to include a [commitlint](https://github.com/marionebl/commitlint/issues/272#issuecomment-366037861) property.
+
+```json
+{
+	"commitlint": {
+		"extends": [
+			"@peakfijn/config-commitlint"
+		]
+	}
+}
+```
+
+## Usage
+
+After installing and configuring the package, you can use it by running this command.
+
+```bash
+$ npx commitlint --to HEAD
+```

--- a/@peakfijn/config-commitlint/index.js
+++ b/@peakfijn/config-commitlint/index.js
@@ -1,0 +1,3 @@
+const config = require('commitlint-config-peakfijn');
+
+module.exports = config;

--- a/@peakfijn/config-commitlint/package.json
+++ b/@peakfijn/config-commitlint/package.json
@@ -1,0 +1,28 @@
+{
+	"name": "@peakfijn/config-commitlint",
+	"version": "0.6.1",
+	"description": "Sharable configuration for Commitlint with Peakfijn conventions",
+	"keywords": [
+		"commitlint",
+		"config",
+		"peakfijn"
+	],
+	"author": "Cedric van Putten <cedric@peakfijn.nl>",
+	"license": "MIT",
+	"main": "index.js",
+	"homepage": "https://github.com/peakfijn/conventions/tree/develop/@peakfijn/config-commitlint#readme",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/peakfijn/conventions.git"
+	},
+	"bugs": {
+		"url": "https://github.com/peakfijn/conventions/issues"
+	},
+	"scripts": {
+		"test": "node -c index.js"
+	},
+	"dependencies": {
+		"commitlint": "^7.1.2",
+		"commitlint-config-peakfijn": "0.6.1"
+	}
+}

--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -2,6 +2,7 @@
 	"groups": {
 		"default": {
 			"packages": [
+				"@peakfijn/config-commitlint/package.json",
 				"@peakfijn/config-release-expo/package.json",
 				"@peakfijn/config-release-laravel/package.json",
 				"package.json",


### PR DESCRIPTION
This allows us to "implement" commitlint using only `npm install --save-dev @peakfijn/commitlint` and the `package.json` configuration.