### PR TITLE
documentation(config-release-expo): use the new uniform readme format

### DIFF
--- a/@peakfijn/config-release-expo/README.md
+++ b/@peakfijn/config-release-expo/README.md
@@ -1,9 +1,8 @@
 # Expo - Peakfijn Releases
 
-A sharable Semantic Releases configuration for Expo projects.
-All required dependencies are contained in this one, so you only have to list this.
+A sharable [Semantic Release](https://github.com/semantic-release/semantic-release) configuration for [Expo](https://github.com/expo/expo-cli) projects.
 
-## Install
+## Installation
 
 Install the dependency with npm.
 
@@ -11,7 +10,7 @@ Install the dependency with npm.
 $ npm install --save-dev @peakfijn/config-release-expo
 ```
 
-## Usage
+## Configuration
 
 Update the `package.json` to include a [release](https://github.com/semantic-release/semantic-release/blob/caribou/docs/usage/configuration.md#configuration) property.
 
@@ -34,4 +33,12 @@ And make sure `package.json` also contains the basic repository (**git url**) in
 		"url": "git@bitbucket.org:peakfijn/<project>.git"
 	}
 }
+```
+
+## Usage
+
+After installing and configuring the package, you can use it by running this command.
+
+```bash
+$ npx semantic-release'
 ```


### PR DESCRIPTION
Use the same read me format as all (new) others.