### PR TITLE
documentation: add helpful github templates for issues and pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Create a report to help us improve
+---
+
+### Description of the bug
+How would you shortly summarise the issue?
+
+### To Reproduce
+What steps did you perform which led to this issue?
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+
+#### Expected behavior
+What did you expect to have happened?
+
+#### Actual behavior
+What did it actually result in?
+
+### Additional context
+Can you further explain the issue? E.g., information about version/environment or screenshots.

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,13 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+---
+
+### Description of the feature
+How would you briefly summarise the feature?
+
+### Motivation
+Why does this feature should be implemented?
+
+### Additional context
+Can you further explain the feature? E.g., screenshots or real-world examples.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+### Linked issue
+Provide the issue(s) which this pull request relates to or fixes.
+
+### Additional context
+Are there things the maintainers should be aware of before merging or closing this pull request?


### PR DESCRIPTION
It will not only help "outsiders", but also (new) interns breaking information up into separate small and easy questions.