### PR TITLE
fix(commitizen): space in the beginning of subject is causing commitlint to fail

### DIFF
--- a/packages/cz-changelog-peakfijn/index.js
+++ b/packages/cz-changelog-peakfijn/index.js
@@ -48,8 +48,8 @@ module.exports = {
 
 			cz.prompt(questions).then(function (answers) {
 				const scope = answers.scope ? `(${answers.scope})` : '';
-				const head = `${answers.type}${scope}: ${answers.subject}`;
-				const footer = (answers.footer || '').split(' ').join('\n');
+				const head = `${answers.type}${scope}: ${answers.subject.trim()}`;
+				const footer = (answers.footer.trim() || '').split(' ').join('\n');
 
 				const commitMessage = `${head}\n\n${answers.body}\n\n${footer}`.trim();
 

--- a/packages/cz-changelog-peakfijn/index.js
+++ b/packages/cz-changelog-peakfijn/index.js
@@ -49,7 +49,7 @@ module.exports = {
 			cz.prompt(questions).then(function (answers) {
 				const scope = answers.scope ? `(${answers.scope})` : '';
 				const head = `${answers.type}${scope}: ${answers.subject.trim()}`;
-				const footer = (answers.footer.trim() || '').split(' ').join('\n');
+				const footer = (answers.footer || '').trim().split(' ').join('\n');
 
 				const commitMessage = `${head}\n\n${answers.body}\n\n${footer}`.trim();
 


### PR DESCRIPTION
### Linked issue
[Double space in the beginning of commit message doesn't pass commit linters but passed Commitizen](https://github.com/Peakfijn/Conventions/issues/40)

### Additional context
The way I 'fixed' this, is by trimming the subject (I additionally also trimmed the footer) so that even when you add a additional space or subject in the beginning of those entities, they'll be trimmed away before you even commit.