### PR TITLE
fix(stylelint): add support for both approaches to stylelint binaries

### DIFF
--- a/@peakfijn/config-stylelint/bin/stylelint
+++ b/@peakfijn/config-stylelint/bin/stylelint
@@ -4,6 +4,6 @@ const resolvePkg = require('resolve-pkg');
 
 const directory = resolvePkg('stylelint', { cwd: __dirname });
 const manifest = require(path.resolve(directory, 'package.json'));
-const bin = path.resolve(directory, manifest.bin);
+const bin = path.resolve(directory, manifest.bin.stylelint || manifest.bin);
 
 require(bin);


### PR DESCRIPTION
### Linked issue
Fixes the binary proxy issue once and for all. It adds support for both approaches, depending on the node version etc.