### PR TITLE
refactor(commitlint): lower minimum length of subject to `15`

### DIFF
--- a/packages/commitlint-config-peakfijn/index.js
+++ b/packages/commitlint-config-peakfijn/index.js
@@ -3,7 +3,7 @@ const config = require('@commitlint/config-conventional');
 
 config.rules['header-max-length'] = [2, 'always', 80];
 config.rules['scope-empty'] = [2, 'always'];
-config.rules['subject-min-length'] = [2, 'always', 20];
+config.rules['subject-min-length'] = [2, 'always', 15];
 config.rules['type-enum'] = [2, 'always', Object.keys(commitTypes)];
 
 module.exports = config;

--- a/packages/commitlint-config-peakfijn/index.test.js
+++ b/packages/commitlint-config-peakfijn/index.test.js
@@ -25,10 +25,10 @@ test('scope-empty is defined as an error and always applicable', t => {
 	));
 });
 
-test('subject-min-length is defined as error, always applicable and set to 20 characters', t => {
+test('subject-min-length is defined as error, always applicable and set to 15 characters', t => {
 	t.true(isEqual(
 		rules['subject-min-length'],
-		[2, 'always', 20],
+		[2, 'always', 15],
 	));
 });
 


### PR DESCRIPTION
### Linked issue
There were some valid comments about the length of the subject. The value `20` came from the original `header-min-length` rule. But this is now changed to `subject-*` only because of the big differences in commit type. I think this will be a welcome change for some people.