### PR TITLE
refactor: upgrade semantic-release-expo to version 2.1.2

### DIFF
--- a/@peakfijn/config-release-expo/package.json
+++ b/@peakfijn/config-release-expo/package.json
@@ -40,7 +40,7 @@
 		"release-rules-peakfijn": "1.0.0-rc.2",
 		"resolve-pkg": "^1.0.0",
 		"semantic-release": "^15.9.15",
-		"semantic-release-expo": "^2.1.0",
+		"semantic-release-expo": "^2.1.2",
 		"semantic-release-git-branches": "^1.2.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
### Linked issue
Greenkeeper backlog.
