### PR TITLE
refactor: upgrade ava to version 1.2.0

### DIFF
--- a/packages/conventional-changelog-peakfijn/package.json
+++ b/packages/conventional-changelog-peakfijn/package.json
@@ -32,7 +32,7 @@
 		"q": "^1.5.1"
 	},
 	"devDependencies": {
-		"ava": "^1.0.1",
+		"ava": "^1.2.0",
 		"conventional-commits-parser": "^3.0.1",
 		"lodash": "^4.17.11",
 		"xo": "^0.24.0"


### PR DESCRIPTION
### Linked issue
Greenkeeper backlog.