### PR TITLE
refactor(stylelint): upgrade resolve-pkg to version 2.0.0

### DIFF
--- a/@peakfijn/config-stylelint/package.json
+++ b/@peakfijn/config-stylelint/package.json
@@ -30,7 +30,7 @@
 		"test": "ava"
 	},
 	"dependencies": {
-		"resolve-pkg": "^1.0.0",
+		"resolve-pkg": "^2.0.0",
 		"stylelint": "^9.5.0",
 		"stylelint-config-peakfijn": "1.0.0-rc.3"
 	},


### PR DESCRIPTION
### Linked issue
Upgrades resolve pkg to the latest version in stylelint, a manual upgrade to enable greenkeeper again.