### PR TITLE
refactor(stylelint): upgrade stylelint to version 10.0.1

### DIFF
--- a/@peakfijn/config-stylelint/package.json
+++ b/@peakfijn/config-stylelint/package.json
@@ -31,7 +31,7 @@
 	},
 	"dependencies": {
 		"resolve-pkg": "^2.0.0",
-		"stylelint": "^9.5.0",
+		"stylelint": "^10.0.1",
 		"stylelint-config-peakfijn": "1.0.0-rc.3"
 	},
 	"devDependencies": {


### PR DESCRIPTION
### Linked issue
Upgrades stylelint to the latest version in stylelint, a manual upgrade to enable greenkeeper again.