### PR TITLE
refactor(commitlint): upgrade resolve-pkg to version 2.0.0

### DIFF
--- a/@peakfijn/config-commitlint/package.json
+++ b/@peakfijn/config-commitlint/package.json
@@ -32,7 +32,7 @@
 	"dependencies": {
 		"commitlint": "^7.4.0",
 		"commitlint-config-peakfijn": "1.0.0-rc.3",
-		"resolve-pkg": "^1.0.0"
+		"resolve-pkg": "^2.0.0"
 	},
 	"devDependencies": {
 		"ava": "^1.2.0",


### PR DESCRIPTION
### Linked issue
Upgrades resolve pkg to the latest version in commitlint, a manual upgrade to enable greenkeeper again.