### PR TITLE
refactor(eslint): upgrade babel-eslint to version 10.0.1

### DIFF
--- a/@peakfijn/config-eslint-expo/package.json
+++ b/@peakfijn/config-eslint-expo/package.json
@@ -31,7 +31,7 @@
 		"test": "ava"
 	},
 	"dependencies": {
-		"babel-eslint": "^9.0.0",
+		"babel-eslint": "^10.0.1",
 		"eslint": "^5.5.0",
 		"eslint-config-peakfijn-expo": "1.0.0-rc.3",
 		"eslint-import-resolver-babel-module": "^5.0.1",


### PR DESCRIPTION
### Linked issue
Upgrades babel eslint to the latest version in eslint, a manual upgrade to enable greenkeeper again.
