### PR TITLE
refactor(semantic-release): upgrade resolve-pkg to version 2.0.0

### DIFF
--- a/@peakfijn/config-release-expo/package.json
+++ b/@peakfijn/config-release-expo/package.json
@@ -38,7 +38,7 @@
 		"@semantic-release/release-notes-generator": "^7.0.2",
 		"conventional-changelog-peakfijn": "1.0.0-rc.3",
 		"release-rules-peakfijn": "1.0.0-rc.3",
-		"resolve-pkg": "^1.0.0",
+		"resolve-pkg": "^2.0.0",
 		"semantic-release": "^15.9.15",
 		"semantic-release-expo": "^2.1.2",
 		"semantic-release-git-branches": "^1.2.1"

--- a/@peakfijn/config-release-laravel/package.json
+++ b/@peakfijn/config-release-laravel/package.json
@@ -38,7 +38,7 @@
 		"@semantic-release/release-notes-generator": "^7.0.0",
 		"conventional-changelog-peakfijn": "1.0.0-rc.3",
 		"release-rules-peakfijn": "1.0.0-rc.3",
-		"resolve-pkg": "^1.0.0",
+		"resolve-pkg": "^2.0.0",
 		"semantic-release": "^15.9.5",
 		"semantic-release-git-branches": "^1.2.1"
 	},

--- a/@peakfijn/config-release-react/package.json
+++ b/@peakfijn/config-release-react/package.json
@@ -39,7 +39,7 @@
 		"conventional-changelog-peakfijn": "1.0.0-rc.3",
 		"release-rules-peakfijn": "1.0.0-rc.3",
 		"semantic-release": "^15.13.3",
-		"resolve-pkg": "^1.0.0",
+		"resolve-pkg": "^2.0.0",
 		"semantic-release-git-branches": "^1.2.1"
 	},
 	"devDependencies": {

--- a/@peakfijn/config-release/package.json
+++ b/@peakfijn/config-release/package.json
@@ -41,7 +41,7 @@
 		"@semantic-release/release-notes-generator": "^7.1.4",
 		"conventional-changelog-peakfijn": "1.0.0-rc.3",
 		"release-rules-peakfijn": "1.0.0-rc.3",
-		"resolve-pkg": "^1.0.0",
+		"resolve-pkg": "^2.0.0",
 		"semantic-release": "^15.13.2"
 	},
 	"devDependencies": {


### PR DESCRIPTION
### Linked issue
Upgrades resolve pkg to the latest version in semantic release, a manual upgrade to enable greenkeeper again.
