### PR TITLE
pipeline: remove node 11 from test versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: node_js
 node_js:
   - 12
-  - 11
   - 10
   - 8
 cache:


### PR DESCRIPTION
### Linked issue
Node 11 is scheduled to EOL at 2019-06-01, which is pretty soon. Now that to-be LTS Node 12 is out, we can remove Node 11.

### Additional context
https://nodejs.org/en/about/releases/