### PR TITLE
refactor: exclude package lock updates by greenkeeper from commitlint

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,26 @@
+module.exports = {
+    extends: [
+        './packages/commitlint-config-peakfijn',
+    ],
+    rules: {
+        'scope-empty': [
+            0,
+        ],
+        'scope-enum': [
+            2,
+            'always',
+            [
+                'changelog',
+                'commitizen',
+                'commitlint',
+                'eslint',
+                'semantic-release',
+                'stylelint',
+            ],
+        ],
+    },
+    ignores: [
+        // fix: ignore lockfile updates by greenkeeper
+		commit => commit.startsWith('chore(package):'),
+	],
+};

--- a/package.json
+++ b/package.json
@@ -26,29 +26,6 @@
 		"lerna": "^3.15.0",
 		"xo": "^0.24.0"
 	},
-	"commitlint": {
-		"extends": [
-			"./packages/commitlint-config-peakfijn"
-		],
-		"rules": {
-			"scope-empty": [
-				0
-			],
-			"scope-enum": [
-				2,
-				"always",
-				[
-					"changelog",
-					"commitizen",
-					"commitlint",
-					"eslint",
-					"package",
-					"semantic-release",
-					"stylelint"
-				]
-			]
-		}
-	},
 	"greenkeeper": {
 		"commitMessages": {
 			"initialBadge": "documentation: add greenkeeper badge",


### PR DESCRIPTION
### Linked issue
This should exclude future commits by greenkeeper, updating lock files. Because this is an automated process and not-configurable, this should not be linted on.
